### PR TITLE
Distinguish between boolish properties and boolean parameters

### DIFF
--- a/lib/puppet/provider/netapp_e_network_interface/netapp_e_network_interface.rb
+++ b/lib/puppet/provider/netapp_e_network_interface/netapp_e_network_interface.rb
@@ -18,14 +18,14 @@ Puppet::Type.type(:netapp_e_network_interface).provide(:netapp_e_network_interfa
           :controller => net_int['controllerRef'],
           :storagesystem => net_int['storagesystem'],
           :interfacename => net_int['interfaceName'],
-          :ipv4 => net_int['ipv4Enabled'],
+          :ipv4 => net_int['ipv4Enabled'].to_s.to_sym,
           :ipv4address => net_int['ipv4Address'],
           :ipv4mask => net_int['ipv4SubnetMask'],
           :ipv4gateway => net_int['ipv4GatewayAddress'],
           :ipv4config => net_int['ipv4AddressConfigMethod'],
-          :ipv6 => net_int['ipv6Enabled'],
+          :ipv6 => net_int['ipv6Enabled'].to_s.to_sym,
           :ipv6config  => net_int['ipv6AddressConfigMethod'],
-          :remoteaccess => net_int['rloginEnabled'],
+          :remoteaccess => net_int['rloginEnabled'].to_s.to_sym,
           :speed => net_int['configuredSpeedSetting']
          )
     end

--- a/lib/puppet/type/netapp_e_network_interface.rb
+++ b/lib/puppet/type/netapp_e_network_interface.rb
@@ -46,8 +46,9 @@ Puppet::Type.newtype(:netapp_e_network_interface) do
     desc 'Name of Ethernet port'
   end
 
-  newproperty(:ipv4, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+  newproperty(:ipv4) do
     desc 'True if ipv4 is to be enabled for this interface; otherwise false.'
+    newvalues(:true, :false)
   end
 
   newproperty(:ipv4address) do
@@ -79,8 +80,9 @@ Puppet::Type.newtype(:netapp_e_network_interface) do
     newvalues('configDhcp', 'configStatic', '__UNDEFINED')
   end
 
-  newproperty(:ipv6, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+  newproperty(:ipv6) do
     desc 'True if ipv6 is to be enabled for this interface; otherwise false.'
+    newvalues(:true, :false)
   end
 
   newparam(:ipv6address) do
@@ -110,9 +112,10 @@ Puppet::Type.newtype(:netapp_e_network_interface) do
     end
   end
 
-  newproperty(:remoteaccess, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+  newproperty(:remoteaccess) do
     desc 'If set to true, the controller is enabled for establishment of a remote access session.
         Depending on the controller platform, the method for remote access could be rlogin or telnet.'
+    newvalues(:true, :false)
   end
 
   newproperty(:speed) do

--- a/spec/puppet/type/netapp_e_network_interface_spec.rb
+++ b/spec/puppet/type/netapp_e_network_interface_spec.rb
@@ -55,7 +55,7 @@ describe Puppet::Type.type(:netapp_e_network_interface) do
       it_behaves_like 'a string param/property', :interfacename, true
     end
     context 'for ipv4' do
-      it_behaves_like 'a boolish param/property', :ipv4
+      it_behaves_like 'a boolish property', :ipv4
     end
     context 'for ipv4address' do
       it_behaves_like 'a IPv4 param/property', :ipv4address
@@ -70,7 +70,7 @@ describe Puppet::Type.type(:netapp_e_network_interface) do
       it_behaves_like 'a enum param/property', :ipv4config, %w(configDhcp configStatic __UNDEFINED)
     end
     context 'for ipv6' do
-      it_behaves_like 'a boolish param/property', :ipv6
+      it_behaves_like 'a boolish property', :ipv6
     end
     context 'for ipv6address' do
       it_behaves_like 'a IPv6 param/property', :ipv6address
@@ -85,7 +85,7 @@ describe Puppet::Type.type(:netapp_e_network_interface) do
       it_behaves_like 'a IPv6 param/property', :ipv6routableaddr
     end
     context 'for remoteaccess' do
-      it_behaves_like 'a boolish param/property', :remoteaccess
+      it_behaves_like 'a boolish property', :remoteaccess
     end
     context 'for speed' do
       it_behaves_like 'a enum param/property', :speed, %w(speedNone speedAutoNegotiated speed10MbitHalfDuplex speed10MbitFullDuplex speed100MbitHalfDuplex speed100MbitFullDuplex speed1000MbitHalfDuplex speed1000MbitFullDuplex __UNDEFINED)

--- a/spec/puppet/type/netapp_e_password_spec.rb
+++ b/spec/puppet/type/netapp_e_password_spec.rb
@@ -52,10 +52,10 @@ describe Puppet::Type.type(:netapp_e_password) do
       it_behaves_like 'a string param/property', :new, true
     end
     context 'for admin' do
-      it_behaves_like 'a boolish param/property', :admin
+      it_behaves_like 'a boolean param', :admin
     end
     context 'for force' do
-      it_behaves_like 'a boolish param/property', :force, false
+      it_behaves_like 'a boolean param', :force, false
     end
     context 'for ensure' do
       it 'should set password when sync' do

--- a/spec/puppet/type/netapp_e_storage_pool_spec.rb
+++ b/spec/puppet/type/netapp_e_storage_pool_spec.rb
@@ -58,7 +58,7 @@ describe Puppet::Type.type(:netapp_e_storage_pool) do
       it_behaves_like 'a string param/property', :id, true
     end
     context 'for erasedrives' do
-      it_behaves_like 'a boolish param/property', :erasedrives, false
+      it_behaves_like 'a boolean param', :erasedrives, false
     end
     context 'for raidlevel' do
       it_behaves_like 'a enum param/property', :raidlevel, %w(raidUnsupported raidAll raid0 raid1 raid3 raid5 raid6 raidDiskPool __UNDEFINED)

--- a/spec/puppet/type/netapp_e_volume_spec.rb
+++ b/spec/puppet/type/netapp_e_volume_spec.rb
@@ -96,7 +96,7 @@ describe Puppet::Type.type(:netapp_e_volume) do
       it_behaves_like 'a string param/property', :segsize, true
     end
     context 'for dataassurance' do
-      it_behaves_like 'a boolish param/property', :dataassurance
+      it_behaves_like 'a boolean param', :dataassurance
     end
     context 'for thin' do
       before :each do
@@ -104,7 +104,7 @@ describe Puppet::Type.type(:netapp_e_volume) do
                         :maxrepositorysize => '1',
                         :repositorysize => '2')
       end
-      it_behaves_like 'a boolish param/property', :thin, false
+      it_behaves_like 'a boolean param', :thin, false
     end
     context 'for repositorysize' do
       it_behaves_like 'a string param/property', :repositorysize, true
@@ -119,13 +119,13 @@ describe Puppet::Type.type(:netapp_e_volume) do
       it_behaves_like 'a string param/property', :growthalertthreshold, true
     end
     context 'for defaultmapping' do
-      it_behaves_like 'a boolish param/property', :defaultmapping
+      it_behaves_like 'a boolean param', :defaultmapping
     end
     context 'for expansionpolicy' do
       it_behaves_like 'a enum param/property', :expansionpolicy, %w(unknown manual automatic __UNDEFINED)
     end
     context 'for cachereadahead' do
-      it_behaves_like 'a boolish param/property', :cachereadahead
+      it_behaves_like 'a boolean param', :cachereadahead
     end
   end
 end


### PR DESCRIPTION
Puppet::Parameter::Boolean is dedicated for parameters and should not be
used with properties.