### PR TITLE
Add ASUP tracking for Puppet usage

### DIFF
--- a/lib/puppet/util/network_device/netapp_e/device.rb
+++ b/lib/puppet/util/network_device/netapp_e/device.rb
@@ -21,6 +21,15 @@ class Puppet::Util::NetworkDevice::Netapp_e::Device
     @transport ||= NetApp::ESeries::Api.new(@url.user, @url.password, "#{@url.scheme}://#{@url.host}:#{@url.port}#{@url.path.chomp('/')}", true, 15)
 
     @transport.login
+
+    # post presence of Puppet module to key/value pair for ASUP posting
+    client_info = {
+        'application' => 'Puppet',
+        'app-version' => Facter.value(:puppetversion),
+        'url'         => redacted_url
+    }.to_json
+
+    @transport.post_key_value('Puppet', client_info)
   end
 
   def facts

--- a/lib/puppet/util/network_device/netapp_e/netapp_e_series_api.rb
+++ b/lib/puppet/util/network_device/netapp_e/netapp_e_series_api.rb
@@ -473,6 +473,11 @@ class NetApp
         status(response, 204, 'Failed to delete mirror group members')
       end
 
+      def post_key_value(key, value)
+        response = request(:post, "/devmgr/v2/key-values/#{key}", value)
+        status(response, 200, 'Failed to add key/value pair')
+      end
+
       private
 
       # Determine the status of the response


### PR DESCRIPTION
This change adds tracking of the Puppet module into the E-Series system
so we can monitor adoption.